### PR TITLE
Feat deb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
   - make lint
 
 after_success:
-  - coveralls
+  - coveralls --data_file tests/.coverage

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,42 @@
+VERSION  = $(shell cat VERSION)
+
 clean:
 	-rm -rf build
 	-rm -rf dist
 	-rm -rf *.egg-info
 	-rm -f tests/.coverage
 	-rm container_shell.spec
+	-rm -rf ContainerShell-*/
 	-docker rm $(shell docker ps -aq)
 	-docker rmi $(shell docker images -q --filter "dangling=true")
 
 whl: clean
-	python setup.py bdist_wheel --universal
-
-binary: clean
-	pyinstaller -F container_shell/container_shell.py
+	python setup.py bdist_wheel
 
 uninstall:
 	-pip uninstall -y container-shell
 
 install: uninstall whl
 	pip install --trusted-host pypi.org -U dist/*.whl
+
+binary: install
+	pyinstaller -F container_shell/container_shell.py
+
+deb:
+	mkdir -p ContainerShell-$(VERSION)/DEBIAN/
+	mkdir -p ContainerShell-$(VERSION)/usr/bin/
+	mkdir -p ContainerShell-$(VERSION)/etc/container_shell/
+	cp sample.config.ini ContainerShell-$(VERSION)/etc/container_shell/
+	cp dist/container_shell ContainerShell-$(VERSION)/usr/bin/
+	cp postinst ContainerShell-$(VERSION)/DEBIAN/
+	cp control ContainerShell-$(VERSION)/DEBIAN/
+	sed -i -e 's/VERSION/'$(VERSION)'/g' ContainerShell-$(VERSION)/DEBIAN/control
+	sudo chown root:root -R ContainerShell-$(VERSION)
+	dpkg -b ContainerShell-$(VERSION)
+	mv ContainerShell*.deb dist/
+
+pkgs: binary deb
+
 
 lint:
 	pylint container_shell

--- a/control
+++ b/control
@@ -1,0 +1,7 @@
+Package: ContainerShell
+Version: VERSION
+Architecture: amd64
+Maintainer: Nicholas Willhite <willnx84@gmail.com>
+Depends: docker-ce
+Homepage: https://github.com/willnx/container_shell
+Description: Like other shells, but drops users into a Docker container instead.

--- a/postinst
+++ b/postinst
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# While not "by the books" for a Debian package, there's no promise that the
+# the GID of the docker group on *my* machine is the same as another persons.
+# So this post-install script will ensure that the correct permissions are
+# applied so the container_shell binary will work after installation
+
+chown :docker /usr/bin/container_shell
+chmod g+s /usr/bin/container_shell
+
+mkdir -p /var/log/container_shell
+# Yeah, this is a bit cheesy, but it:
+#   A) Centralized the location of the log file
+#   B) Allows all users to write to it, without opening all of /var/log
+# If you have a better idea, I'd love to hear what it is!
+chmod 777 /var/log/container_shell


### PR DESCRIPTION
It's possible to package Container Shell into a `.deb` file! Honestly, it's not the best `.deb`, but it works, and is probably fair for someone's 1st ever _go at it_.

To make the `.deb` you can run: `make pkgs`

The `make deb` works if you manually run `make binary` first. Because I'm going to also make an RPM, it seemed dumb to define a make command that would result in building the same binary twice 😅 