### PR TITLE
Can now build RPM an package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ man/
 site-packages/
 lib-python/
 lib_pypy/
+
+# So the source RPM spec isn't auto ignored
+!container_shell.rpm.spec

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ clean:
 	-rm -f tests/.coverage
 	-rm container_shell.spec
 	-rm -rf ContainerShell-*/
-	-rm -rf rpmbuild
 	-docker rm $(shell docker ps -aq)
 	-docker rmi $(shell docker images -q --filter "dangling=true")
 

--- a/container_shell.rpm.spec
+++ b/container_shell.rpm.spec
@@ -1,0 +1,45 @@
+Name: ContainerShell
+Version: VERSION
+Release: 1
+Summary: Drops you into a container, instead of the host environment.
+License: Apache2
+Requires: docker-ce
+Source0: ContainerShell-VERSION.tar.gz
+Url: https://github.com/willnx/container_shell
+
+%description
+ To run a docker command you need to be root or part of the docker group (which
+ effectively is root). Container Shell avoids this by leveraging the setgid
+ permission, allowing a user that is not part of the docker group the ability to
+ access a admin-defined container.
+
+%prep
+%setup -q
+
+%build
+
+%install
+echo ${buildroot}
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+
+cp -R * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%post
+chown :docker /usr/bin/container_shell
+chmod g+s /usr/bin/container_shell
+
+mkdir -p /var/log/container_shell
+# Yeah, this is a bit cheesy, but it:
+#   A) Centralized the location of the log file
+#   B) Allows all users to write to it, without opening all of /var/log
+# If you have a better idea, I'd love to hear what it is!
+chmod 777 /var/log/container_shell
+
+
+%files
+/usr/bin/container_shell
+/etc/container_shell/sample.config.ini


### PR DESCRIPTION
It's pretty simple to build an RPM package now. Just like the `deb` commit, if you want to build *only* an RPM you must run `make binary` then `make rpm`. However, if you want to build _"all the things"_, just run `make pkgs` 😄 

While doing some initial testing, I learned about this aspect of [pyinstaller](https://pyinstaller.readthedocs.io/en/stable/usage.html?highlight=glibc#making-gnu-linux-apps-forward-compatible) _the hard way._ So when I built the packages on Ubuntu 18.04 and attempted to run the binary after installing the RPM on CentOS 7, I got this gem:

```
$ /usr/bin/container_shell
[23626] Error loading Python lib '/tmp/_MEIRLaqT4/libpython3.6m.so.1.0': dlopen: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /tmp/_MEIRLaqT4/libpython3.6m.so.1.0)
```

Per pyinstaller, the solution is straightforward: build the binary on the _oldest_ thing you can find because `glibc` is backwards compatible. I checked the version of `glibc` on Ubuntu 14.04, and it's actually newer than CentOS 7's version 😅. Guess I'll be building these on CentOS 7 then!