### PR TITLE
Default image is now debian because it has expected tooling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,8 +44,7 @@ format, so it's easy to modify.
 If no file exists, then Container Shell will assume some defaults. The main
 section you'll want to adjust for your installation is the ``config`` section,
 where you can define which container image a user will be placed into. By default,
-Container Shell will use `busybox <https://hub.docker.com/_/busybox>`_ (just
-because it's so small).
+Container Shell will use the latest `debian <https://www.debian.org/>`_ image.
 
 A sample config is installed to ``/etc/container_shell/sample.config.ini``, which
 will have additional context. But if you're checking out the repo, the sample

--- a/container_shell/lib/config.py
+++ b/container_shell/lib/config.py
@@ -40,7 +40,7 @@ def _default():
     config.add_section('qos')
     config.add_section('binaries')
 
-    config.set('config', 'image', 'busybox:latest')
+    config.set('config', 'image', 'debian:latest')
     config.set('config', 'hostname', 'someserver')
     config.set('config', 'auto_refresh', '')
     config.set('config', 'skip_users', '')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,7 @@ class TestDefault(unittest.TestCase):
         test_config.add_section('qos')
         test_config.add_section('binaries')
 
-        test_config.set('config', 'image', 'busybox:latest')
+        test_config.set('config', 'image', 'debian:latest')
         test_config.set('config', 'hostname', 'someserver')
         test_config.set('config', 'auto_refresh', '')
         test_config.set('config', 'skip_users', '')


### PR DESCRIPTION
While testing the RPM, I found this bug!

Turns out, busybox (and alpine) don't ship with `runuser`. So instead of changing the default behavior to *not* auto re-create the user _inside_ the container, I opted to use debian.