### PR TITLE
Recommends tag for an RPM is a Fedora/SUSE specific thing...

### DIFF
--- a/container_shell.rpm.spec
+++ b/container_shell.rpm.spec
@@ -3,7 +3,6 @@ Version: VERSION
 Release: 1
 Summary: Drops you into a container, instead of the host environment.
 License: Apache2
-Recommends: docker-ce docker-engine
 Source0: ContainerShell-VERSION.tar.gz
 Url: https://github.com/willnx/container_shell
 


### PR DESCRIPTION
I learned about the `Recommends` tag here:
https://rpm.org/user_doc/dependencies.html

Being `rpm.org`, it appeared to be pretty legit. Turns out, RHEL wont backport it to EL7:
https://bugzilla.redhat.com/show_bug.cgi?id=1538566

I knew I liked `.deb` packing more, and now I have more reasons... 😒 